### PR TITLE
Reorder translated messages and fix en->ja tag for jap. translation

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8,62 +8,62 @@ common:
     content:
       - lang: en
         text: 'Delete. Already included in %1%.'
-      - lang: ru
-        text: 'Удалите. Уже включено в %1%.'
-      - lang: es
-        text: 'Borrar. Esta incluido en %1%.'
-      - lang: ko
-        text: '삭제하십시오. 이미 %1%에 포함되어 있습니다.'
-      - lang: zh_CN
-        text: '删除。已包含在%1%中。'
       - lang: da
         text: 'Slet. Allerede inkluderet i %1%.'
-      - lang: ja
-        text: '削除してください。既に%1%に含まれています。'
       - lang: de
         text: 'Löschen. Bereits in %1% enthalten.'
+      - lang: es
+        text: 'Borrar. Esta incluido en %1%.'
+      - lang: ja
+        text: '削除してください。既に%1%に含まれています。'
+      - lang: ko
+        text: '삭제하십시오. 이미 %1%에 포함되어 있습니다.'
       - lang: pt
         text: 'Apagar. Já incluído em %1%.'
+      - lang: ru
+        text: 'Удалите. Уже включено в %1%.'
+      - lang: zh_CN
+        text: '删除。已包含在%1%中。'
 
   - &deletePlugin
     type: warn
     content:
       - lang: en
         text: 'When using **%1%**. It''s recommended that you deactivate or delete this ESP file, but keep the resources (e.g. meshes, textures) installed with this mod. As they''re still required by **%1%**.'
-      - lang: ru
-        text: 'Пока используется **%1%**, рекомендуется отключить или удалить esp этого мода, но оставить установленные ресурсы (meshes, textures). Т.к. они все еще требуются для **%1%**.'
       - lang: de
         text: 'Beim nutzen von **%1%** ist es empfohlen das Sie die ESP-Datei deaktivieren oder löschen, aber die mitgelieferten Mittel (z.B Meshes, Texturen) beibehalten die mit dieser Mod mitinstalliert wurden. Diese werden immer noch von **%1%** vorausgesetzt.'
+      - lang: ja
+        text: '**%1%**を使用中の場合。このespファイルは無効化あるいは削除するのはおすすめしますが、このmodによってインストールされたリソース(メッシュ、テクスチャなど)はそのままにしておいてください。これらは**%1%**によって引き続き必要とされてます。'
       - lang: ko
         text: '**%1%** 모드를 사용중일 떈, 이 ESP 파일을 삭제하고 함께 설치된 리소스(예: 메쉬, 텍스쳐)만 남겨두는 걸 권장합니다. 리소스는 **%1%** 모드에서 필요로 합니다.'
-      - lang: en
-        text: '**%1%**を使用中の場合。このespファイルは無効化あるいは削除するのはおすすめしますが、このmodによってインストールされたリソース(メッシュ、テクスチャなど)はそのままにしておいてください。これらは**%1%**によって引き続き必要とされてます。'
+      - lang: pl
+        text: 'Używając **%1%**, jest rekomendowane abyś dezaktywował lub usunął ten plik ESP, ale pozostawił zasoby (siatki, tekstury) zainstalowane z tym modem. Ponieważ są wciąż wymagane przez **%1%**.'
       - lang: pt
         text: 'Ao utilizar **%1%**, é recomendado que você desative ou apage este ficheiro ESP, mas mantenha os recursos (ex. meshes, texturas) instalados por este mod. Sendo que os mesmos ainda são necessitados por **%1%**. '
       - lang: pt_BR
         text: 'Quando se usa **%1%**, é recomendado que você desative ou delete este arquivo ESP, mas que mantenha os recursos (ex. meshes, texturas) que vieram com esse mod.'
-      - lang: pl
-        text: 'Używając **%1%**, jest rekomendowane abyś dezaktywował lub usunął ten plik ESP, ale pozostawił zasoby (siatki, tekstury) zainstalowane z tym modem. Ponieważ są wciąż wymagane przez **%1%**.'
+      - lang: ru
+        text: 'Пока используется **%1%**, рекомендуется отключить или удалить esp этого мода, но оставить установленные ресурсы (meshes, textures). Т.к. они все еще требуются для **%1%**.'
 
   - &obsolete
     type: say
     content:
       - lang: en
         text: 'Obsolete. Update to the latest version. %1%'
-      - lang: ru
-        text: 'Устарело. Обновите до последней версии. %1%'
-      - lang: es
-        text: 'Obsoleto. Actualizar a la última versión. %1%'
-      - lang: ko
-        text: '사용되지 않습니다. 최신 버전으로 업데이트하십시오. %1%'
-      - lang: zh_CN
-        text: '已过时。请升级到最新版本。 %1%'
       - lang: da
         text: 'Forældet. Opdatér til den nyeste version. %1%'
-      - lang: ja
-        text: '旧式のプラグインです。最新版に更新してください。 %1%'
       - lang: de
         text: 'Veraltet. Aktualisere zur letzten Version. %1%'
+      - lang: es
+        text: 'Obsoleto. Actualizar a la última versión. %1%'
+      - lang: ja
+        text: '旧式のプラグインです。最新版に更新してください。 %1%'
+      - lang: ko
+        text: '사용되지 않습니다. 최신 버전으로 업데이트하십시오. %1%'
+      - lang: ru
+        text: 'Устарело. Обновите до последней версии. %1%'
+      - lang: zh_CN
+        text: '已过时。请升级到最新版本。 %1%'
     subs: [ '' ]
 
   - &useInstead
@@ -79,20 +79,20 @@ common:
     content:
       - lang: en
         text: 'Use only one %1%.'
-      - lang: ru
-        text: 'Используйте только один %1%.'
-      - lang: es
-        text: 'Utilizar solo un %1%.'
-      - lang: ko
-        text: '%1%을 한 개만 사용하십시오.'
-      - lang: zh_CN
-        text: '只使用一个%1%。'
-      - lang: ja
-        text: '%1%は一つだけ使用してください。'
       - lang: de
         text: 'Nutzen Sie nur einen %1%.'
+      - lang: es
+        text: 'Utilizar solo un %1%.'
+      - lang: ja
+        text: '%1%は一つだけ使用してください。'
+      - lang: ko
+        text: '%1%을 한 개만 사용하십시오.'
       - lang: pt
         text: 'Utilizar apenas um %1%.'
+      - lang: ru
+        text: 'Используйте только один %1%.'
+      - lang: zh_CN
+        text: '只使用一个%1%。'
 
 bash_tags: []
 
@@ -101,22 +101,22 @@ globals:
     content:
       - lang: en
         text: '[Latest LOOT thread](%1%).'
-      - lang: ru
-        text: '[Обсуждение LOOT "(Eng)"](%1%).'
-      - lang: es
-        text: '[Forum de LOOT](%1%).'
-      - lang: ko
-        text: '[최신 LOOT 스레드](%1%).'
-      - lang: zh_CN
-        text: '[最新的LOOT版本](%1%)。'
       - lang: da
         text: '[Seneste LOOT-tråd](%1%).'
-      - lang: ja
-        text: '[LOOTの最新スレッドを開く](%1%)（英語）'
       - lang: de
         text: '[Aktueller LOOT-Thread](%1%).'
+      - lang: es
+        text: '[Forum de LOOT](%1%).'
+      - lang: ja
+        text: '[LOOTの最新スレッドを開く](%1%)（英語）'
+      - lang: ko
+        text: '[최신 LOOT 스레드](%1%).'
       - lang: pt
         text: '[Postagem mais recente do LOOT](%1%).'
+      - lang: ru
+        text: '[Обсуждение LOOT "(Eng)"](%1%).'
+      - lang: zh_CN
+        text: '[最新的LOOT版本](%1%)。'
     subs: [ 'https://loot.github.io/latest-thread/' ]
 
 groups:


### PR DESCRIPTION
Use this order for translations:
`en cs da de es fi fr ja ko pl pt pt_BR ru sv zh_CN`