### PR TITLE
Change message type of &obsolete and &useOnlyOneX

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -93,7 +93,7 @@ common:
         text: 'Använd %1% istället.'
 
   - &useOnlyOneX
-    type: say
+    type: error
     content:
       - lang: en
         text: 'Use only one %1%.'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -56,7 +56,7 @@ common:
         text: 'När du använder **%1%** är det rekommenderat att du avaktiverar eller tar bort denna ESP-fil, men behåll resurserna (meshar och texturer) installerade med denna mod. De krävs fortfarande av **%1%**.'
 
   - &obsolete
-    type: say
+    type: warn
     content:
       - lang: en
         text: 'Obsolete. Update to the latest version. %1%'


### PR DESCRIPTION
`Obsolete. Update to latest version. %1%`
For SLE, SSE, Oblivion, FO3, FO4 and FNV the type of `&obsolete` is set to `warn`, not `say`.

As such, change it for Morrowind to `warn` as well.

`Use only one %1%.`
For SLE, SSE, Oblivion, FO3 and FNV the type of `&useOnlyOneX` is set to `error`, not `say`.

As such, change it for Morrowind to `error` as well.