### PR TITLE
Additional message for multipatch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -801,6 +801,7 @@ plugins:
         content:
           - lang: en
             text: 'Delete before generating [Merged Objects.esp](https://www.nexusmods.com/morrowind/mods/46870/), to avoid cyclic dependency.'
+
 ###### Resources & Frameworks ######
   - name: 'OAAB_Data.esm'
     url: [ 'https://www.nexusmods.com/morrowind/mods/49042/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -796,10 +796,11 @@ plugins:
       - type: say
         content:
           - lang: en
-            text:
-              - 'Regenerate after adding or removing mods or generating [Merged Objects.esp](https://www.nexusmods.com/morrowind/mods/46870/)'
-              - 'Delete before generating [Merged Objects.esp](https://www.nexusmods.com/morrowind/mods/46870/), to avoid cyclic dependency'
-
+            text: 'Regenerate after adding or removing mods or generating [Merged Objects.esp](https://www.nexusmods.com/morrowind/mods/46870/)'
+      - type: say
+        content:
+          - lang: en
+            text: 'Delete before generating [Merged Objects.esp](https://www.nexusmods.com/morrowind/mods/46870/), to avoid cyclic dependency.'
 ###### Resources & Frameworks ######
   - name: 'OAAB_Data.esm'
     url: [ 'https://www.nexusmods.com/morrowind/mods/49042/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -796,8 +796,9 @@ plugins:
       - type: say
         content:
           - lang: en
-            text: 'Regenerate after adding or removing mods or generating [Merged Objects.esp](https://www.nexusmods.com/morrowind/mods/46870/)'
-            text: 'Delete before generating [Merged Objects.esp](https://www.nexusmods.com/morrowind/mods/46870/), to avoid cyclic dependency'
+            text:
+              - 'Regenerate after adding or removing mods or generating [Merged Objects.esp](https://www.nexusmods.com/morrowind/mods/46870/)'
+              - 'Delete before generating [Merged Objects.esp](https://www.nexusmods.com/morrowind/mods/46870/), to avoid cyclic dependency'
 
 ###### Resources & Frameworks ######
   - name: 'OAAB_Data.esm'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -797,6 +797,7 @@ plugins:
         content:
           - lang: en
             text: 'Regenerate after adding or removing mods or generating [Merged Objects.esp](https://www.nexusmods.com/morrowind/mods/46870/)'
+            text: 'Delete before generating [Merged Objects.esp](https://www.nexusmods.com/morrowind/mods/46870/), to avoid cyclic dependency'
 
 ###### Resources & Frameworks ######
   - name: 'OAAB_Data.esm'


### PR DESCRIPTION
Added advice to delete multipatch before generating merged objects file to avoid cyclic dependency.
Now with approximately 50% more message per message.