### PR TITLE
Add Skill Framework

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -883,6 +883,14 @@ plugins:
       - 'StatsWindow.ESP'
       - 'StatsWindow.omwscripts'
 
+  - name: 'SkillFramework\.omwscripts'
+    url:
+      - link: 'https://www.nexusmods.com/morrowind/mods/57765/'
+        name: 'Skill Framework'
+    after:
+      - 'StatsWindow.ESP'
+      - 'StatsWindow.omwscripts'
+
 ###### Gameplay - User Interface ######
 ###### Gameplay - User Interface - Map markers ######
 ###### Gameplay - User Interface - Maps ######


### PR DESCRIPTION
This will conflict with #120 and #121, will rebase this when they are merged

\* Add main plugin
\- SkillFramework.omwscripts

\* Add 'location' key to main plugin
\- https://www.nexusmods.com/morrowind/mods/57765/

\* Add 'after' key to main plugin
\- Needs to be loaded after Stats Window Extender